### PR TITLE
Enum was being compared to a string

### DIFF
--- a/src/yuca/src/main/java/yuca/linux/thermal/SysThermalCooldown.java
+++ b/src/yuca/src/main/java/yuca/linux/thermal/SysThermalCooldown.java
@@ -51,15 +51,15 @@ final class SysThermalCooldown {
   }
 
   private static int[] findX86ThermalZones() {
-    return getThermalZonesByType("x86_pkg_temp");
+    return getThermalZonesByType(ThermalZoneKind.X86_PKG_TEMP);
   }
 
-  private static int[] getThermalZonesByType(String type) {
+  private static int[] getThermalZonesByType(ThermalZoneKind type) {
     ArrayList<Integer> zones = new ArrayList<>();
     IntStream.range(0, SysThermal.getZoneCount())
         .forEach(
             zone -> {
-              if (SysThermal.getZoneType(zone) == ThermalZoneKind.parseZoneName(type)) {
+              if (SysThermal.getZoneType(zone) == type) {
                 zones.add(zone);
               }
             });

--- a/src/yuca/src/main/java/yuca/linux/thermal/SysThermalCooldown.java
+++ b/src/yuca/src/main/java/yuca/linux/thermal/SysThermalCooldown.java
@@ -59,7 +59,7 @@ final class SysThermalCooldown {
     IntStream.range(0, SysThermal.getZoneCount())
         .forEach(
             zone -> {
-              if (SysThermal.getZoneType(zone).equals(type)) {
+              if (SysThermal.getZoneType(zone) == ThermalZoneKind.parseZoneName(type)) {
                 zones.add(zone);
               }
             });


### PR DESCRIPTION
In `yuca.linux.thermal.SysThermalCooldown`, SysThermal.getZoneType(zone) returned a Enum and it was being compared to a string. The cooldown is now fixed and works.