### PR TITLE
Fixed amortized carbon logic

### DIFF
--- a/service/src/main/python/yuca/symbols/linux.py
+++ b/service/src/main/python/yuca/symbols/linux.py
@@ -202,24 +202,28 @@ class TaskEmissionsProcessor(SignalProcessor):
 # Transistor gap temperature
 T = -(0.075 * 0.070 / 0.9 - 0.1897) / (8.6173303 * 10**-5)
 
+# lifespan is 10 years in seconds
+cpu_lifespan = 315360000
+cpu_embodied_carbon = 10274.2
 
 def compute_amortized_carbon(temperature, frequency, normal_temperature, normal_frequency):
     norm = temperature.copy(deep=True)
-    norm[norm < normal_temperature] = normal_temperature
+    norm[norm > normal_temperature] = normal_temperature
     # e^(T/temp) / e^(T/normal temp) = e^(T/temp - T/normal temp) = e^(T * (1 /temp - 1/normal temp))
-    age = np.exp(T * (1 / (273 + temperature) - T / (273 + norm)))
+    age = np.exp(T * (1 / (273 + temperature) - 1 / (273 + norm)))
+
     df = pd.concat(
         [frequency.unstack('cpu'), age],
         axis=1
     )
     dfs = []
     for _, df in df.groupby('socket'):
-        df = df.sort_index().ffill().dropna()
+        df = df.sort_index().ffill().dropna(axis=1, how='all').dropna(axis=0)
         age = df.pop('value')
         for col in df.columns:
             norm = df[col].copy(deep=True)
-            norm[norm < normal_frequency] = normal_frequency
-            df[col] = age * df[col] / df[col]
+            norm[norm > normal_frequency] = normal_frequency
+            df[col] = (age * df[col] / norm) * (cpu_embodied_carbon / cpu_lifespan)
         df.columns.name = 'cpu'
         dfs.append(df.stack())
     amortized = pd.concat(dfs)

--- a/service/src/main/python/yuca/symbols/linux.py
+++ b/service/src/main/python/yuca/symbols/linux.py
@@ -218,6 +218,8 @@ def compute_amortized_carbon(temperature, frequency, normal_temperature, normal_
     )
     dfs = []
     for _, df in df.groupby('socket'):
+        #  multiple dropna calls required if system has multiple sockets, and frequency is split between the cores
+        #  ie. on a machine with 40 cores. socket:0 has frequency values on cores 0-23 and socket:1 has frequency values on 24-47
         df = df.sort_index().ffill().dropna(axis=1, how='all').dropna(axis=0)
         age = df.pop('value')
         for col in df.columns:

--- a/service/src/main/python/yuca/symbols/linux.py
+++ b/service/src/main/python/yuca/symbols/linux.py
@@ -1,7 +1,9 @@
 import logging
 
 import numpy as np
+import scipy as sp
 import pandas as pd
+
 
 from yuca.signal_pb2 import Signal
 from yuca.symbols.symbol import SOCKET_POWER
@@ -199,11 +201,22 @@ class TaskEmissionsProcessor(SignalProcessor):
         ).set_index(['timestamp', 'socket', 'cpu', 'task', 'component']).value
 
 
+# boltzmann's constant in eV/K
+k_b, _, _ = sp.constants.physical_constants['Boltzmann constant in eV/K']
+# poisson parameter for trap distribution in eV nm/V
+B = 0.075
+# transistor channel energy in eV
+E_0 = 0.1897
+# supply voltage in V
+v_dd = 0.070
+# equivalent oxide thickness in nm
+t_ox = 0.9
 # Transistor gap temperature
-T = -(0.075 * 0.070 / 0.9 - 0.1897) / (8.6173303 * 10**-5)
+T = -(B * v_dd / t_ox - E_0) / k_b
 
 # TODO: Need to be customizable based on device
 # lifespan is 10 years in seconds
+# embodied_carbon is in grams
 cpu_lifespan = 315360000
 cpu_embodied_carbon = 10274.2
 

--- a/service/src/main/python/yuca/symbols/linux.py
+++ b/service/src/main/python/yuca/symbols/linux.py
@@ -209,6 +209,47 @@ cpu_embodied_carbon = 10274.2
 
 
 def compute_amortized_carbon(temperature, frequency, normal_temperature, normal_frequency):
+    """
+    This code is not fully tested but appears to work as expected based on this script:
+
+    from itertools import product
+
+    import math
+    import pandas as pd
+    import numpy as np
+
+    from yuca.symbols.linux import compute_amortized_carbon
+
+    freq_index = pd.MultiIndex.from_tuples(
+        product([1767403714251088000, 1767403714251088010],
+                list(range(2)), list(range(9))),
+        names=["timestamp", "socket", "cpu"]
+    )
+
+    freq = pd.Series(
+        [10e9] * len(freq_index),
+        index=freq_index,
+        name="value"
+    )
+
+    temp_index = pd.MultiIndex.from_tuples(
+        product([1767403714251088005, 1767403714251088015], list(range(2))),
+        names=["timestamp", "socket"]
+    )
+
+    temp = pd.Series(
+        [37] * len(temp_index),
+        index=temp_index,
+        name="value"
+    )
+
+    result = compute_amortized_carbon(temp, freq, 40, 1800000000)
+    assert math.isclose(
+        result.sum(),
+        0.000181 * len(result),
+        rel_tol=1e-4
+    )
+    """
     norm = temperature.copy(deep=True)
     norm[norm > normal_temperature] = normal_temperature
     # e^(T/temp) / e^(T/normal temp) = e^(T/temp - T/normal temp) = e^(T * (1 /temp - 1/normal temp))
@@ -234,48 +275,6 @@ def compute_amortized_carbon(temperature, frequency, normal_temperature, normal_
     amortized.name = 'value'
     return amortized
 
-
-"""
-This code is not fully tested but appears to work as expected based on this script:
-
-from itertools import product
-
-import math
-import pandas as pd
-import numpy as np
-
-from yuca.symbols.linux import compute_amortized_carbon
-
-freq_index = pd.MultiIndex.from_tuples(
-    product([1767403714251088000, 1767403714251088010],
-            list(range(2)), list(range(9))),
-    names=["timestamp", "socket", "cpu"]
-)
-
-freq = pd.Series(
-    [10e9] * len(freq_index),
-    index=freq_index,
-    name="value"
-)
-
-temp_index = pd.MultiIndex.from_tuples(
-    product([1767403714251088005, 1767403714251088015], list(range(2))),
-    names=["timestamp", "socket"]
-)
-
-temp = pd.Series(
-    [37] * len(temp_index),
-    index=temp_index,
-    name="value"
-)
-
-result = compute_amortized_carbon(temp, freq, 40, 1800000000)
-assert math.isclose(
-    result.sum(),
-    0.000181 * len(result),
-    rel_tol=1e-4
-)
-"""
 
 # maps component type + unit to processing
 PROCESSORS = {

--- a/service/src/main/python/yuca/symbols/linux.py
+++ b/service/src/main/python/yuca/symbols/linux.py
@@ -212,6 +212,7 @@ def compute_amortized_carbon(temperature, frequency, normal_temperature, normal_
     norm = temperature.copy(deep=True)
     norm[norm > normal_temperature] = normal_temperature
     # e^(T/temp) / e^(T/normal temp) = e^(T/temp - T/normal temp) = e^(T * (1 /temp - 1/normal temp))
+    # Temperature must be in Kelvin for aging to prevent unit mismatch
     age = np.exp(T * (1 / (273 + temperature) - 1 / (273 + norm)))
 
     df = pd.concat(

--- a/service/src/main/python/yuca/symbols/linux.py
+++ b/service/src/main/python/yuca/symbols/linux.py
@@ -202,6 +202,7 @@ class TaskEmissionsProcessor(SignalProcessor):
 # Transistor gap temperature
 T = -(0.075 * 0.070 / 0.9 - 0.1897) / (8.6173303 * 10**-5)
 
+# TODO: Need to be customizable based on device
 # lifespan is 10 years in seconds
 cpu_lifespan = 315360000
 cpu_embodied_carbon = 10274.2

--- a/service/src/main/python/yuca/symbols/linux.py
+++ b/service/src/main/python/yuca/symbols/linux.py
@@ -207,6 +207,7 @@ T = -(0.075 * 0.070 / 0.9 - 0.1897) / (8.6173303 * 10**-5)
 cpu_lifespan = 315360000
 cpu_embodied_carbon = 10274.2
 
+
 def compute_amortized_carbon(temperature, frequency, normal_temperature, normal_frequency):
     norm = temperature.copy(deep=True)
     norm[norm > normal_temperature] = normal_temperature
@@ -219,20 +220,61 @@ def compute_amortized_carbon(temperature, frequency, normal_temperature, normal_
     )
     dfs = []
     for _, df in df.groupby('socket'):
-        #  multiple dropna calls required if system has multiple sockets, and frequency is split between the cores
-        #  ie. on a machine with 40 cores. socket:0 has frequency values on cores 0-23 and socket:1 has frequency values on 24-47
         df = df.sort_index().ffill().dropna(axis=1, how='all').dropna(axis=0)
         age = df.pop('value')
         for col in df.columns:
             norm = df[col].copy(deep=True)
             norm[norm > normal_frequency] = normal_frequency
-            df[col] = (age * df[col] / norm) * (cpu_embodied_carbon / cpu_lifespan)
+            df[col] = (age * df[col] / norm) * \
+                (cpu_embodied_carbon / cpu_lifespan)
         df.columns.name = 'cpu'
         dfs.append(df.stack())
     amortized = pd.concat(dfs)
     amortized.name = 'value'
     return amortized
 
+
+"""
+This code is not fully tested but appears to work as expected based on this script:
+
+from itertools import product
+
+import math
+import pandas as pd
+import numpy as np
+
+from yuca.symbols.linux import compute_amortized_carbon
+
+freq_index = pd.MultiIndex.from_tuples(
+    product([1767403714251088000, 1767403714251088010],
+            list(range(2)), list(range(9))),
+    names=["timestamp", "socket", "cpu"]
+)
+
+freq = pd.Series(
+    [10e9] * len(freq_index),
+    index=freq_index,
+    name="value"
+)
+
+temp_index = pd.MultiIndex.from_tuples(
+    product([1767403714251088005, 1767403714251088015], list(range(2))),
+    names=["timestamp", "socket"]
+)
+
+temp = pd.Series(
+    [37] * len(temp_index),
+    index=temp_index,
+    name="value"
+)
+
+result = compute_amortized_carbon(temp, freq, 40, 1800000000)
+assert math.isclose(
+    result.sum(),
+    0.000181 * len(result),
+    rel_tol=1e-4
+)
+"""
 
 # maps component type + unit to processing
 PROCESSORS = {


### PR DESCRIPTION
The amortized logic in `yuca.symbols.linux.py` was incorrect and did not reflect the equation in the paper. As well as some typos in signs `<` versus `>` that didn't filter the temperature and frequency correctly.